### PR TITLE
Customizable hotkey feature added to main.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ change the domain in manifest if applicable
 
 to-do:
 - [ ] change extension icon when active
-- [ ] customizeable hotkey
+- [x] customizeable hotkey
 - [ ] see tags on hover
 - [ ] search tags

--- a/main.js
+++ b/main.js
@@ -1,5 +1,22 @@
+document.addEventListener('keydown', function(event) {
+  if (event.code === 'Backquote') {
+    setKeybinding();
+  }
+});
+
+
+var keybinding;
+
+// function to handle the prompt and button logic
+function setKeybinding() {
+  keybinding = prompt("Enter the key you want to set as the keybinding:");
+  if(keybinding == null || keybinding == "") {
+    keybinding = "default value";
+  }
+}
+
 function keypress(event) {
-	if (event.key === '`' || event.code === 'Backquote') {
+	if (event.key === keybinding) {
 		highlightAndNewTag();
 	}
 }

--- a/main.js
+++ b/main.js
@@ -1,11 +1,10 @@
+var keybinding;
+
 document.addEventListener('keydown', function(event) {
-  if (event.code === 'Backquote') {
+  if (!keybinding && event.code === 'Backquote') {
     setKeybinding();
   }
 });
-
-
-var keybinding;
 
 // function to handle the prompt and button logic
 function setKeybinding() {
@@ -22,7 +21,6 @@ function keypress(event) {
 }
 
 document.addEventListener('keydown', keypress);
-
 function highlightAndNewTag(){
 	var newest = null;
 	var creating = true;


### PR DESCRIPTION
The to-do "customizable hotkey" feature has been added to main.js and marked off on the README.md file.

To use the customizable hotkey feature, press the backquote key ` and a window will prompt you to set the keybinding for tagging. Using the backquote key as a keybinding will not trigger the prompt again.